### PR TITLE
Add automated test suite for AI evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,10 @@ This is a small AI made to solve Sudokus.
 
 ## Usage
 
-You can either use `test.py` with the pretrained `model.pth` (might produce weird results) or retrain it yourself using train.py.
+You can either use `test.py` with the pretrained `model.pth` (might produce weird results) or retrain it yourself using `train.py`.
+
+To run the automated test suite and evaluate the model's performance on multiple puzzles, use the following command:
+
+```
+python test_suite.py
+```

--- a/test_suite.py
+++ b/test_suite.py
@@ -1,0 +1,36 @@
+import numpy as np
+import torch
+from model import Sudokai
+
+def evaluate_model(dataset_path='dataset.npy'):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = torch.load("model.pth").to(device)
+    dataset = np.load(dataset_path, allow_pickle=True)
+    
+    total_loss = 0
+    correct_predictions = 0
+    total_predictions = 0
+    
+    model.eval()
+    
+    for puzzle, solution in dataset:
+        puzzle_tensor = torch.from_numpy(puzzle).float().to(device)
+        solution_tensor = torch.from_numpy(solution).long().to(device)
+        
+        output = model(puzzle_tensor)
+        pred = output.argmax(dim=1, keepdim=True)
+        
+        correct_predictions += pred.eq(solution_tensor.view_as(pred)).sum().item()
+        total_predictions += solution_tensor.nelement()
+        
+        loss = torch.nn.functional.nll_loss(output, solution_tensor, reduction='sum').item()
+        total_loss += loss
+    
+    accuracy = 100. * correct_predictions / total_predictions
+    average_loss = total_loss / total_predictions
+    
+    print(f'Accuracy: {accuracy}%')
+    print(f'Average loss: {average_loss}')
+
+if __name__ == "__main__":
+    evaluate_model()


### PR DESCRIPTION
Implements an automated test suite for evaluating the AI model's performance and updates the README.md with instructions on how to use it.

- Adds `test_suite.py` to systematically evaluate the `Sudokai` model using a dataset loaded from `dataset.npy`. This script calculates and prints out the model's accuracy and average loss, providing a more comprehensive assessment of the AI's performance.
- Updates the `README.md` file to include instructions on running the new automated test suite, ensuring users are aware of how to evaluate the model's performance on multiple puzzles.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PKD667/sudokia?shareId=2184a310-6653-4911-a31d-d35894ee8d49).